### PR TITLE
Replace Metrics without Limits tools with metric tags and search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ LLM がツールを発見するための Progressive Disclosure ツール。
 |---------|-----|------|
 | `datadog_list_active_metrics` | `GET /api/v1/metrics` | アクティブなメトリクス名の一覧取得 |
 | `datadog_query_metrics` | `GET /api/v1/query` | 時系列メトリクスデータのクエリ |
-| `datadog_list_tag_configurations` | `GET /api/v2/metrics` | メトリクスのタグ設定メタデータ検索 |
 | `datadog_get_metric_metadata` | `GET /api/v1/metrics/{metric_name}` | 特定メトリクスのメタデータ取得 |
-| `datadog_list_metric_tags` | `GET /api/v2/metrics/{metric_name}/tags` | 特定メトリクスのタグ設定一覧 |
+| `datadog_list_all_metric_tags` | `GET /api/v2/metrics/{metric_name}/all-tags` | 特定メトリクスの全タグ一覧（ingested タグ含む） |
+| `datadog_search_metrics` | `GET /api/v1/search` | メトリクス名のプレフィックス検索 |
 
 ### Logs（1ツール）
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,9 +7,9 @@ import type {
   SearchMonitorGroupsParams,
   ListActiveMetricsParams,
   QueryMetricsParams,
-  ListTagConfigurationsParams,
   GetMetricMetadataParams,
-  ListMetricTagsParams,
+  ListAllMetricTagsParams,
+  SearchMetricsParams,
   SearchLogsParams,
   SearchRumEventsParams,
 } from './types.js';
@@ -80,27 +80,23 @@ export class DatadogClient {
     return response.data;
   }
 
-  async listTagConfigurations(params: ListTagConfigurationsParams) {
-    const queryParams: Record<string, string | number | boolean | undefined> = {
-      'filter[configured]': params.filter_configured,
-      'filter[tags_configured]': params.filter_tags_configured,
-      'filter[metric_type]': params.filter_metric_type,
-      'filter[include_percentiles]': params.filter_include_percentiles,
-      'filter[queried]': params.filter_queried,
-      'filter[tags]': params.filter_tags,
-      'window[seconds]': params.window_seconds,
-    };
-    const response = await this.client.get('/api/v2/metrics', { params: queryParams });
-    return response.data;
-  }
-
   async getMetricMetadata(params: GetMetricMetadataParams) {
     const response = await this.client.get(`/api/v1/metrics/${params.metricName}`);
     return response.data;
   }
 
-  async listMetricTags(params: ListMetricTagsParams) {
-    const response = await this.client.get(`/api/v2/metrics/${params.metricName}/tags`);
+  async listAllMetricTags(params: ListAllMetricTagsParams) {
+    const queryParams: Record<string, string | number | boolean | undefined> = {};
+    if (params.windowSeconds !== undefined) {
+      queryParams['window[seconds]'] = params.windowSeconds;
+    }
+    const response = await this.client.get(`/api/v2/metrics/${params.metricName}/all-tags`, { params: queryParams });
+    return response.data;
+  }
+
+  async searchMetrics(params: SearchMetricsParams) {
+    const query = params.query.startsWith('metrics:') ? params.query : `metrics:${params.query}`;
+    const response = await this.client.get('/api/v1/search', { params: { q: query } });
     return response.data;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,8 @@ const TOOL_NAMES = [
   'datadog_list_tool_categories', 'datadog_search_tools',
   'datadog_get_error_tracking_issue', 'datadog_search_error_tracking_issues',
   'datadog_list_monitors', 'datadog_get_monitor', 'datadog_search_monitor_groups',
-  'datadog_list_active_metrics', 'datadog_query_metrics', 'datadog_list_tag_configurations',
-  'datadog_get_metric_metadata', 'datadog_list_metric_tags',
+  'datadog_list_active_metrics', 'datadog_query_metrics',
+  'datadog_get_metric_metadata', 'datadog_list_all_metric_tags', 'datadog_search_metrics',
   'datadog_search_logs',
   'datadog_search_rum_events',
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,22 +51,17 @@ export interface QueryMetricsParams {
   query: string;
 }
 
-export interface ListTagConfigurationsParams {
-  filter_configured?: boolean;
-  filter_tags_configured?: string;
-  filter_metric_type?: string;
-  filter_include_percentiles?: boolean;
-  filter_queried?: boolean;
-  filter_tags?: string;
-  window_seconds?: number;
-}
-
 export interface GetMetricMetadataParams {
   metricName: string;
 }
 
-export interface ListMetricTagsParams {
+export interface ListAllMetricTagsParams {
   metricName: string;
+  windowSeconds?: number;
+}
+
+export interface SearchMetricsParams {
+  query: string;
 }
 
 // ─── Logs ───
@@ -133,9 +128,9 @@ export const TOOL_REGISTRY: ToolDefinition[] = [
   // Metrics
   { name: 'datadog_list_active_metrics', category: 'metrics', description: 'List active metrics since a given time', apiMethod: 'GET', apiPath: '/api/v1/metrics' },
   { name: 'datadog_query_metrics', category: 'metrics', description: 'Query timeseries metric data points', apiMethod: 'GET', apiPath: '/api/v1/query' },
-  { name: 'datadog_list_tag_configurations', category: 'metrics', description: 'List metrics with tag configurations', apiMethod: 'GET', apiPath: '/api/v2/metrics' },
   { name: 'datadog_get_metric_metadata', category: 'metrics', description: 'Get metadata for a specific metric by name', apiMethod: 'GET', apiPath: '/api/v1/metrics/{metric_name}' },
-  { name: 'datadog_list_metric_tags', category: 'metrics', description: 'List tag configurations for a specific metric', apiMethod: 'GET', apiPath: '/api/v2/metrics/{metric_name}/tags' },
+  { name: 'datadog_list_all_metric_tags', category: 'metrics', description: 'List all tags for a specific metric including ingested tags', apiMethod: 'GET', apiPath: '/api/v2/metrics/{metric_name}/all-tags' },
+  { name: 'datadog_search_metrics', category: 'metrics', description: 'Search metric names by query prefix', apiMethod: 'GET', apiPath: '/api/v1/search' },
   // Logs
   { name: 'datadog_search_logs', category: 'logs', description: 'Search log events with query filters and time range', apiMethod: 'POST', apiPath: '/api/v2/logs/events/search' },
   // RUM

--- a/tests/error-tracking.test.ts
+++ b/tests/error-tracking.test.ts
@@ -27,7 +27,7 @@ describe('Error Tracking - Client', () => {
     it('issue_id がパスに埋め込まれる', async () => {
       mock.get.mockResolvedValue({ data: { data: { id: 'abc-123', attributes: {} } } });
 
-      const result = await client.getErrorTrackingIssue('abc-123');
+      const result = await client.getErrorTrackingIssue({ issueId: 'abc-123' });
 
       expect(mock.get).toHaveBeenCalledWith('/api/v2/error-tracking/issues/abc-123');
       expect(result.data.id).toBe('abc-123');
@@ -87,7 +87,7 @@ describe('Error Tracking - Client', () => {
       apiError.response = { status: 403, statusText: 'Forbidden', data: { errors: ['Forbidden'] } };
       mock.get.mockRejectedValue(apiError);
 
-      await expect(client.getErrorTrackingIssue('abc')).rejects.toThrow('Request failed');
+      await expect(client.getErrorTrackingIssue({ issueId: 'abc' })).rejects.toThrow('Request failed');
     });
 
     it('ネットワークエラー時に例外が伝播する', async () => {

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { DatadogClient } from '../src/client.js';
+
+vi.mock('axios');
+
+function createMockClient() {
+  const mockAxiosInstance = {
+    get: vi.fn(),
+    post: vi.fn(),
+  };
+  vi.mocked(axios.create).mockReturnValue(mockAxiosInstance as any);
+  const client = new DatadogClient('test-api-key', 'test-app-key', 'datadoghq.com');
+  return { client, mock: mockAxiosInstance };
+}
+
+describe('Metrics - Client', () => {
+  let client: DatadogClient;
+  let mock: ReturnType<typeof createMockClient>['mock'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ({ client, mock } = createMockClient());
+  });
+
+  describe('listAllMetricTags', () => {
+    it('メトリクス名がパスに正しく埋め込まれる', async () => {
+      mock.get.mockResolvedValue({ data: { data: { id: 'system.cpu.user', type: 'metrics' } } });
+
+      await client.listAllMetricTags({ metricName: 'system.cpu.user' });
+
+      expect(mock.get).toHaveBeenCalledWith(
+        '/api/v2/metrics/system.cpu.user/all-tags',
+        expect.objectContaining({ params: expect.any(Object) }),
+      );
+    });
+
+    it('windowSeconds が window[seconds] クエリパラメータとして送信される', async () => {
+      mock.get.mockResolvedValue({ data: { data: {} } });
+
+      await client.listAllMetricTags({ metricName: 'system.cpu.user', windowSeconds: 3600 });
+
+      expect(mock.get).toHaveBeenCalledWith(
+        '/api/v2/metrics/system.cpu.user/all-tags',
+        { params: { 'window[seconds]': 3600 } },
+      );
+    });
+
+    it('windowSeconds が未指定時は params に含まれない', async () => {
+      mock.get.mockResolvedValue({ data: { data: {} } });
+
+      await client.listAllMetricTags({ metricName: 'system.disk.free' });
+
+      const callArgs = mock.get.mock.calls[0];
+      const params = callArgs[1]?.params ?? {};
+      expect(params).not.toHaveProperty('window[seconds]');
+    });
+  });
+
+  describe('searchMetrics', () => {
+    it('metrics: プレフィックスなしのクエリに自動付与される', async () => {
+      mock.get.mockResolvedValue({ data: { results: { metrics: ['system.cpu.user'] } } });
+
+      await client.searchMetrics({ query: 'system.cpu' });
+
+      expect(mock.get).toHaveBeenCalledWith('/api/v1/search', {
+        params: { q: 'metrics:system.cpu' },
+      });
+    });
+
+    it('metrics: プレフィックスありのクエリはそのまま送信される', async () => {
+      mock.get.mockResolvedValue({ data: { results: { metrics: ['aws.ecs.running'] } } });
+
+      await client.searchMetrics({ query: 'metrics:aws.ecs' });
+
+      expect(mock.get).toHaveBeenCalledWith('/api/v1/search', {
+        params: { q: 'metrics:aws.ecs' },
+      });
+    });
+
+    it('パスが /api/v1/search であること', async () => {
+      mock.get.mockResolvedValue({ data: { results: { metrics: [] } } });
+
+      await client.searchMetrics({ query: 'test' });
+
+      expect(mock.get.mock.calls[0][0]).toBe('/api/v1/search');
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    it('API エラー（status 403）が正しくフォーマットされる', async () => {
+      const apiError = new Error('Request failed') as any;
+      apiError.response = { status: 403, statusText: 'Forbidden', data: { errors: ['Forbidden'] } };
+      mock.get.mockRejectedValue(apiError);
+
+      await expect(client.listAllMetricTags({ metricName: 'system.cpu.user' })).rejects.toThrow('Request failed');
+    });
+
+    it('ネットワークエラーが正しく伝播する', async () => {
+      mock.get.mockRejectedValue(new Error('Network Error'));
+
+      await expect(client.searchMetrics({ query: 'test' })).rejects.toThrow('Network Error');
+    });
+  });
+});


### PR DESCRIPTION
- MwL関連2ツール削除 (list_tag_configurations, list_metric_tags)
- 実用的な2ツール追加 (list_all_metric_tags, search_metrics)
- 既存テストの引数不整合修正
- メトリクスツールのユニットテスト追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **破壊的な変更**
  * `getErrorTrackingIssue` メソッドのシグネチャが変更されました（文字列パラメータからオプションオブジェクトへ）
  * メトリクスタグ関連のAPIメソッドが削除されました

* **新機能**
  * メトリクスの全タグを取得できる新しい機能を追加
  * メトリクス名をプレフィックスベースで検索できる新機能を追加

* **テスト**
  * メトリクス機能の包括的なユニットテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->